### PR TITLE
chore: rename repo Dragonfly2 to dragonfly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # api
 
-[![Discussions](https://img.shields.io/badge/discussions-on%20github-blue?style=flat-square)](https://github.com/dragonflyoss/Dragonfly2/discussions)
+[![Discussions](https://img.shields.io/badge/discussions-on%20github-blue?style=flat-square)](https://github.com/dragonflyoss/dragonfly/discussions)
 [![LICENSE](https://img.shields.io/github/license/dragonflyoss/api.svg?style=flat-square)](https://github.com/dragonflyoss/api/blob/main/LICENSE)
 
 Canonical location of the Dragonfly API definition.
@@ -9,7 +9,7 @@ The project includes the api definitions of dragonfly services and the mocks of 
 ## Note to developers
 
 If developers need to change dragonfly api definition,
-please contact [dragonfly maintainers](https://github.com/dragonflyoss/Dragonfly2/blob/main/MAINTAINERS.md).
+please contact [dragonfly maintainers](https://github.com/dragonflyoss/dragonfly/blob/main/MAINTAINERS.md).
 
 ## Community
 
@@ -18,15 +18,15 @@ Join the conversation and help the community.
 - **Slack Channel**: [#dragonfly](https://cloud-native.slack.com/messages/dragonfly/) on [CNCF Slack](https://slack.cncf.io/)
 - **Discussion Group**: <dragonfly-discuss@googlegroups.com>
 - **Developer Group**: <dragonfly-developers@googlegroups.com>
-- **Github Discussions**: [Dragonfly Discussion Forum](https://github.com/dragonflyoss/Dragonfly2/discussions)
+- **Github Discussions**: [Dragonfly Discussion Forum](https://github.com/dragonflyoss/dragonfly/discussions)
 - **Twitter**: [@dragonfly_oss](https://twitter.com/dragonfly_oss)
 - **DingTalk**: [22880028764](https://qr.dingtalk.com/action/joingroup?code=v1,k1,pkV9IbsSyDusFQdByPSK3HfCG61ZCLeb8b/lpQ3uUqI=&_dt_no_comment=1&origin=11)
 
 ## Contributing
 
 You should check out our
-[CONTRIBUTING](https://github.com/dragonflyoss/Dragonfly2/blob/main/CONTRIBUTING.md) and develop the project together.
+[CONTRIBUTING](https://github.com/dragonflyoss/dragonfly/blob/main/CONTRIBUTING.md) and develop the project together.
 
 ## Code of Conduct
 
-Please refer to our [Code of Conduct](https://github.com/dragonflyoss/Dragonfly2/blob/main/CODE_OF_CONDUCT.md).
+Please refer to our [Code of Conduct](https://github.com/dragonflyoss/dragonfly/blob/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes several updates to the `README.md` file to correct the URLs for various resources related to the Dragonfly project. The most important changes include updating the links to the GitHub discussions, maintainers, contributing guidelines, and code of conduct.

Updates to URLs in `README.md`:

* Updated the GitHub discussions link to point to the correct repository. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L21-R32)
* Updated the maintainers link to point to the correct repository.
* Updated the contributing guidelines link to point to the correct repository.
* Updated the code of conduct link to point to the correct repository.
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/dragonflyoss/dragonfly/issues/3714
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
