### PR TITLE
chore: bump golang version to 1.23.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module d7y.io/api/v2
 
-go 1.23.0
+go 1.23.8
 
 require (
 	github.com/envoyproxy/protoc-gen-validate v1.2.1


### PR DESCRIPTION
This pull request includes a minor update to the Go module file `go.mod`. The change updates the Go version used in the project from `1.23.0` to `1.23.8`.

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Updated the Go version from `1.23.0` to `1.23.8` to ensure compatibility with the latest features and security patches.<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
