### PR TITLE
chore(README.md): add maintainer google groups for communication channels and remove discussion group

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ please contact [dragonfly maintainers](https://github.com/dragonflyoss/dragonfly
 Join the conversation and help the community.
 
 - **Slack Channel**: [#dragonfly](https://cloud-native.slack.com/messages/dragonfly/) on [CNCF Slack](https://slack.cncf.io/)
-- **Discussion Group**: <dragonfly-discuss@googlegroups.com>
+- **Github Discussions**: [Dragonfly Discussion Forum][discussion]
 - **Developer Group**: <dragonfly-developers@googlegroups.com>
-- **Github Discussions**: [Dragonfly Discussion Forum](https://github.com/dragonflyoss/dragonfly/discussions)
+- **Maintainer Group**: <dragonfly-maintainers@googlegroups.com>
 - **Twitter**: [@dragonfly_oss](https://twitter.com/dragonfly_oss)
 - **DingTalk**: [22880028764](https://qr.dingtalk.com/action/joingroup?code=v1,k1,pkV9IbsSyDusFQdByPSK3HfCG61ZCLeb8b/lpQ3uUqI=&_dt_no_comment=1&origin=11)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ please contact [dragonfly maintainers](https://github.com/dragonflyoss/dragonfly
 Join the conversation and help the community.
 
 - **Slack Channel**: [#dragonfly](https://cloud-native.slack.com/messages/dragonfly/) on [CNCF Slack](https://slack.cncf.io/)
-- **Github Discussions**: [Dragonfly Discussion Forum][discussion]
+- **Github Discussions**: [Dragonfly Discussion Forum](https://github.com/dragonflyoss/dragonfly/discussions)
 - **Developer Group**: <dragonfly-developers@googlegroups.com>
 - **Maintainer Group**: <dragonfly-maintainers@googlegroups.com>
 - **Twitter**: [@dragonfly_oss](https://twitter.com/dragonfly_oss)


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the contact information in the `README.md` file for the Dragonfly project. The changes include replacing outdated discussion group links with updated ones and reorganizing the listed contact methods.

Updates to contact information:

* Replaced the outdated "Discussion Group" email (`dragonfly-discuss@googlegroups.com`) with a link to the GitHub Discussions forum using a reference `[discussion]`.
* Replaced the "GitHub Discussions" link with a new "Maintainer Group" email (`dragonfly-maintainers@googlegroups.com`).
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
