### PR TITLE
docs(README): update community engagement section

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,16 @@ please contact [dragonfly maintainers](https://github.com/dragonflyoss/dragonfly
 
 ## Community
 
-Join the conversation and help the community.
+Join the conversation and help the community grow. Here are the ways to get involved:
 
 - **Slack Channel**: [#dragonfly](https://cloud-native.slack.com/messages/dragonfly/) on [CNCF Slack](https://slack.cncf.io/)
-- **Github Discussions**: [Dragonfly Discussion Forum](https://github.com/dragonflyoss/dragonfly/discussions)
+- **Github Discussions**: [Dragonfly Discussion Forum][discussion]
 - **Developer Group**: <dragonfly-developers@googlegroups.com>
-- **Maintainer Group**: <dragonfly-maintainers@googlegroups.com>
+- **Mailing Lists**:
+  - **Developers**: <dragonfly-developers@googlegroups.com>
+  - **Maintainers**: <dragonfly-maintainers@googlegroups.com>
 - **Twitter**: [@dragonfly_oss](https://twitter.com/dragonfly_oss)
-- **DingTalk**: [22880028764](https://qr.dingtalk.com/action/joingroup?code=v1,k1,pkV9IbsSyDusFQdByPSK3HfCG61ZCLeb8b/lpQ3uUqI=&_dt_no_comment=1&origin=11)
+- **DingTalk Group**: `22880028764`
 
 ## Contributing
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the `README.md` to improve the clarity and organization of the Community section, making it easier for users to find ways to get involved with the Dragonfly project.

Community section improvements:

* Clarified the invitation to join the community and listed specific ways to get involved.
* Updated the GitHub Discussions link to use a reference-style link for consistency.
* Grouped mailing lists under a new "Mailing Lists" subsection, separating Developers and Maintainers for clarity.
* Renamed "DingTalk" to "DingTalk Group" and displayed the group ID in code formatting for better readability.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
