### PR TITLE
docs: update GitHub Discussions link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ please contact [dragonfly maintainers](https://github.com/dragonflyoss/dragonfly
 Join the conversation and help the community grow. Here are the ways to get involved:
 
 - **Slack Channel**: [#dragonfly](https://cloud-native.slack.com/messages/dragonfly/) on [CNCF Slack](https://slack.cncf.io/)
-- **Github Discussions**: [Dragonfly Discussion Forum][discussion]
+- **Github Discussions**: [Dragonfly Discussion Forum](https://github.com/dragonflyoss/dragonfly/discussions)
 - **Developer Group**: <dragonfly-developers@googlegroups.com>
 - **Mailing Lists**:
   - **Developers**: <dragonfly-developers@googlegroups.com>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the `README.md` to fix the link to the Dragonfly Discussion Forum on GitHub Discussions.

Documentation update:

* Corrected the URL for the "Github Discussions" entry to point directly to the Dragonfly Discussions page.
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/dragonflyoss/dragonfly/issues/4425
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
