### PR TITLE
build: upgrade Rust toolchain to 1.88.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,9 @@ name: Lint
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   golang-lint:
@@ -44,7 +44,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-          toolchain: 1.85.0
+          toolchain: 1.88.0
 
       - name: Run cargo check
         uses: actions-rs/cargo@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.85.0
+          toolchain: 1.88.0
 
       - name: Install dependencies
         run: |

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.88.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the Rust toolchain version used in the project from 1.85.0 to 1.88.0 across configuration files and CI workflows. This ensures consistency and allows the project to take advantage of improvements and fixes in the newer Rust release.

Toolchain version updates:

* Updated the Rust toolchain version to 1.88.0 in the `lint.yml` GitHub Actions workflow (`.github/workflows/lint.yml`).
* Updated the Rust toolchain version to 1.88.0 in the `release.yml` GitHub Actions workflow (`.github/workflows/release.yml`).
* Added a `rust-toolchain.toml` file specifying Rust 1.88.0 as the default toolchain for the project.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
